### PR TITLE
Allow scanning of roms that do not have file extensions

### DIFF
--- a/EmuLibrary/RomTypes/MultiFile/MultiFileScanner.cs
+++ b/EmuLibrary/RomTypes/MultiFile/MultiFileScanner.cs
@@ -53,7 +53,7 @@ namespace EmuLibrary.RomTypes.MultiFile
                     {
                         var dirEnumerator = new SafeFileEnumerator(file.FullName, "*.*", SearchOption.AllDirectories);
                         // First matching rom of first valid extension that has any matches. Ex. for "m3u,cue,bin", make sure we don't grab a bin file when there's an m3u or cue handy
-                        var rom = imageExtensionsLower.Select(ext => dirEnumerator.FirstOrDefault(f => f.Extension.TrimStart('.').ToLower() == ext)).FirstOrDefault(f => f != null);
+                        var rom = imageExtensionsLower.Select(ext => dirEnumerator.FirstOrDefault(f => HasMatchingExtension(f, ext))).FirstOrDefault(f => f != null);
                         if (rom != null)
                         {
                             var baseFileName = StringExtensions.GetPathWithoutAllExtensions(Path.GetFileName(file.Name));
@@ -107,7 +107,7 @@ namespace EmuLibrary.RomTypes.MultiFile
                     {
                         var dirEnumerator = new SafeFileEnumerator(file.FullName, "*.*", SearchOption.AllDirectories);
                         // First matching rom of first valid extension that has any matches. Ex. for "m3u,cue,bin", make sure we don't grab a bin file when there's an m3u or cue handy
-                        var rom = imageExtensionsLower.Select(ext => dirEnumerator.FirstOrDefault(f => f.Extension.TrimStart('.').ToLower() == ext)).FirstOrDefault(f => f != null);
+                        var rom = imageExtensionsLower.Select(ext => dirEnumerator.FirstOrDefault(f => HasMatchingExtension(f, ext))).FirstOrDefault(f => f != null);
                         if (rom != null)
                         {
                             var fileInfo = new FileInfo(rom.FullName);

--- a/EmuLibrary/RomTypes/RomTypeScanner.cs
+++ b/EmuLibrary/RomTypes/RomTypeScanner.cs
@@ -3,6 +3,7 @@ using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
 using System;
 using System.Collections.Generic;
+using System.IO.Abstractions;
 using System.Threading;
 
 namespace EmuLibrary.RomTypes
@@ -24,5 +25,10 @@ namespace EmuLibrary.RomTypes
         }
         public abstract IEnumerable<GameMetadata> GetGames(EmulatorMapping mapping, LibraryGetGamesArgs args);
         public abstract IEnumerable<Game> GetUninstalledGamesMissingSourceFiles(CancellationToken ct);
+        
+        protected static bool HasMatchingExtension(FileSystemInfoBase file, string extension)
+        {
+            return file.Extension.TrimStart('.').ToLower() == extension || (file.Extension == "" && extension == "<none>");
+        }
     }
 }

--- a/EmuLibrary/RomTypes/SingleFile/SingleFileScanner.cs
+++ b/EmuLibrary/RomTypes/SingleFile/SingleFileScanner.cs
@@ -54,7 +54,7 @@ namespace EmuLibrary.RomTypes.SingleFile
                         if (args.CancelToken.IsCancellationRequested)
                             yield break;
 
-                        if (file.Extension.TrimStart('.') == extension && !s_discXpattern.IsMatch(file.Name))
+                        if (HasMatchingExtension(file, extension) && !s_discXpattern.IsMatch(file.Name))
                         {
                             var baseFileName = StringExtensions.GetPathWithoutAllExtensions(Path.GetFileName(file.Name));
                             var gameName = StringExtensions.NormalizeGameName(baseFileName);
@@ -105,7 +105,7 @@ namespace EmuLibrary.RomTypes.SingleFile
                         if (args.CancelToken.IsCancellationRequested)
                             yield break;
 
-                        if (file.Extension.TrimStart('.') == extension && !s_discXpattern.IsMatch(file.Name))
+                        if (HasMatchingExtension(file, extension) && !s_discXpattern.IsMatch(file.Name))
                         {
                             var equivalentInstalledPath = Path.Combine(dstPath, file.Name);
                             if (File.Exists(equivalentInstalledPath))


### PR DESCRIPTION
Xbox Live Arcade roms do not have file extensions. Playnite's built-in emulator profile for Xenia supports roms without file extensions by associating the emulator profile with the dummy `<none>` extension. 

The default emulator profile:
<img width="764" alt="image" src="https://github.com/psychonic/Playnite-EmuLibrary/assets/1131174/9682baf1-1ddc-44ec-9cc9-ceb493fbb0b1">

At the moment, EmuLibrary does not handle these, and so XBLA roms are ignored when a scan is executed.

See https://github.com/JosefNemec/Playnite/blob/ef9effdd273f1448f05d53c3f5eacc5448d6f1ee/source/Playnite/Emulation/Emulators/Xenia/emulator.yaml#L8 for the default emulator profile configuration.

And here's the built-in scanner: https://github.com/JosefNemec/Playnite/blob/ef9effdd273f1448f05d53c3f5eacc5448d6f1ee/source/Playnite/Emulators/Scanner.cs#L907

This pull request ensures that both single and multi-file scanners consider roms without file extensions where the emulator profile is configured with extension `<none>`.

Successful import:
<img width="748" alt="image" src="https://github.com/psychonic/Playnite-EmuLibrary/assets/1131174/708e484a-b5f2-4069-98b5-33e14e04cec6">

