### PR TITLE
Reset installing state upon failed installs

### DIFF
--- a/EmuLibrary/RomTypes/MultiFile/MultiFileInstallController.cs
+++ b/EmuLibrary/RomTypes/MultiFile/MultiFileInstallController.cs
@@ -35,7 +35,6 @@ namespace EmuLibrary.RomTypes.MultiFile
                 try
                 {
                     var sourceFolder = new DirectoryInfo(info.SourceFullBaseDir);
-                    var sourceFile = new FileInfo(Path.Combine(sourceFolder.FullName, info.SourceFilePath));
 
                     var fc = new FolderCopier()
                     {
@@ -62,6 +61,7 @@ namespace EmuLibrary.RomTypes.MultiFile
                 }
                 catch (Exception ex)
                 {
+                    Game.IsInstalling = false;
                     _emuLibrary.Playnite.Notifications.Add(Game.GameId, $"Failed to install {Game.Name}.{Environment.NewLine}{Environment.NewLine}{ex}", NotificationType.Error);
                     throw;
                 }

--- a/EmuLibrary/RomTypes/SingleFile/SingleFileInstallController.cs
+++ b/EmuLibrary/RomTypes/SingleFile/SingleFileInstallController.cs
@@ -58,6 +58,7 @@ namespace EmuLibrary.RomTypes.SingleFile
                 }
                 catch (Exception ex)
                 {
+                    Game.IsInstalling = false;
                     _emuLibrary.Playnite.Notifications.Add(Game.GameId, $"Failed to install {Game.Name}.{Environment.NewLine}{Environment.NewLine}{ex}", NotificationType.Error);
                     throw;
                 }


### PR DESCRIPTION
Originally raised in #4 but moving into a separate PR for housekeeping purposes. This PR fixes a minor bug which occurs upon failed installations. The game installing flag is not being reset after a failure, so this change simply corrects that. This ensures that the user is aware that the install process has been completed, even though it failed.