### PR TITLE
Uninstall action improvements and minor fixes

### DIFF
--- a/EmuLibrary/RomTypes/MultiFile/MultiFileUninstallController.cs
+++ b/EmuLibrary/RomTypes/MultiFile/MultiFileUninstallController.cs
@@ -4,6 +4,7 @@ using Playnite.SDK.Plugins;
 using System;
 using System.IO;
 using System.Linq;
+using System.Windows;
 
 namespace EmuLibrary.RomTypes.MultiFile
 {
@@ -19,17 +20,17 @@ namespace EmuLibrary.RomTypes.MultiFile
 
         public override void Uninstall(UninstallActionArgs args)
         {
-            var gameImagePathResolved = Game.Roms.First().Path.Replace(ExpandableVariables.PlayniteDirectory, _emuLibrary.Playnite.Paths.ApplicationPath);
-            var info = new FileInfo(gameImagePathResolved);
-            if (info.Exists)
+            var gameInstallDirectoryResolved = Game.InstallDirectory.Replace(ExpandableVariables.PlayniteDirectory, _emuLibrary.Playnite.Paths.ApplicationPath);
+            if (new DirectoryInfo(gameInstallDirectoryResolved).Exists)
             {
-                Directory.Delete(Game.InstallDirectory.Replace(ExpandableVariables.PlayniteDirectory, _emuLibrary.Playnite.Paths.ApplicationPath), true);
-                InvokeOnUninstalled(new GameUninstalledEventArgs());
+                Directory.Delete(gameInstallDirectoryResolved, true);
             }
             else
             {
-                throw new ArgumentException($"\"{info.FullName}\" does not exist");
+                _emuLibrary.Playnite.Dialogs.ShowMessage($"\"{Game.Name}\" does not appear to be installed. Marking as uninstalled.", "Game not installed", MessageBoxButton.OK);
             }
+            Game.Roms.Clear();
+            InvokeOnUninstalled(new GameUninstalledEventArgs());
         }
     }
 }

--- a/EmuLibrary/RomTypes/SingleFile/SingleFileUninstallController.cs
+++ b/EmuLibrary/RomTypes/SingleFile/SingleFileUninstallController.cs
@@ -4,6 +4,7 @@ using Playnite.SDK.Plugins;
 using System;
 using System.IO;
 using System.Linq;
+using System.Windows;
 
 namespace EmuLibrary.RomTypes.SingleFile
 {
@@ -20,16 +21,16 @@ namespace EmuLibrary.RomTypes.SingleFile
         public override void Uninstall(UninstallActionArgs args)
         {
             var gameImagePathResolved = Game.Roms.First().Path.Replace(ExpandableVariables.PlayniteDirectory, _emuLibrary.Playnite.Paths.ApplicationPath);
-            var info = new FileInfo(gameImagePathResolved);
-            if (info.Exists)
+            if (new FileInfo(gameImagePathResolved).Exists)
             {
                 File.Delete(gameImagePathResolved);
-                InvokeOnUninstalled(new GameUninstalledEventArgs());
             }
             else
             {
-                throw new ArgumentException($"\"{info.FullName}\" does not exist");
+                _emuLibrary.Playnite.Dialogs.ShowMessage($"\"{Game.Name}\" does not appear to be installed. Marking as uninstalled.", "Game not installed", MessageBoxButton.OK);
             }
+            Game.Roms.Clear();
+            InvokeOnUninstalled(new GameUninstalledEventArgs());
         }
     }
 }


### PR DESCRIPTION
Improves the uninstall actions:

Multi-file rom types:
* Fixes a minor bug where the primary rom file within the install directory was being deleted, but not the whole folder. The uninstall action will now clean up the entire folder.

Single and multi-file rom types:

* The list of roms assigned to the game are now cleared after the uninstall is completed. This reverts the game back to it's pure "uninstalled" state.
* If the rom to delete can no longer be found when triggering the uninstall action, then the game will now be marked as uninstalled regardless of whether the controller was able to delete the files or not. This ensures that the game installation state is correct. The message "{Game.Name} does not appear to be installed. Marking as uninstalled." is displayed to the user when this edge case arises. This would only really happen if the user deletes the file manually, or if they are sharing/syncing a Playnite instance between multiple devices.
